### PR TITLE
Bringing compatibility with networkx >= 2.0

### DIFF
--- a/metis.py
+++ b/metis.py
@@ -584,7 +584,7 @@ def networkx_to_metis(G):
             except TypeError:
                 raise TypeError("Node sizes must be integers")
 
-        for j, attr in H.edge[i].items():
+        for j, attr in H.adj[i].items():
             adjncy[e] = j
             if edgew:
                 try:


### PR DESCRIPTION
In their migration notes they mention how G.adj is still valid in both
versions, so I though that's the easiest way to go.